### PR TITLE
Fix backend crashing on simultaneous calls for accounts/candidates

### DIFF
--- a/db.js
+++ b/db.js
@@ -14,9 +14,10 @@ const testDB = async () => {
 const devDB = async () => {
   const db = new Low(new JSONFile('localdb.json'))
   await db.read()
-  // Migrate devDB data by updating seedData.js
-  db.data = seedData
-  await db.write()
+  if (!db.data) {
+    db.data = seedData
+    await db.write()
+  }
   return db
 }
 
@@ -32,10 +33,10 @@ const prodDB = async () => {
     ),
   )
   await db.read()
-  // Migrate data by updating seedData.js Each prod deploy will overwrite the
-  // existing data in S3 with seedData.js
-  db.data = seedData
-  await db.write()
+  if (!db.data) {
+    db.data = seedData
+    await db.write()
+  }
   return db
 }
 

--- a/encryption.js
+++ b/encryption.js
@@ -1,5 +1,4 @@
 import sodium from 'libsodium-wrappers'
-import jwt from 'jsonwebtoken'
 
 const key = process.env.ENCRYPTION_SECRET_KEY
 
@@ -12,16 +11,23 @@ const encrypt = async plaintext => {
   return {ciphertext: ciphertext.toString('hex'), nonce: nonce.toString('hex')}
 }
 
-const decrypt = async ({ciphertext, nonce}) => {
-  await sodium.ready
-  let decrypted = Buffer.from(
-    sodium.crypto_secretbox_open_easy(
-      Buffer.from(ciphertext, 'hex'),
-      Buffer.from(nonce, 'hex'),
-      Buffer.from(key, 'hex'),
-    ),
-  )
-  return sodium.to_string(decrypted)
+const decrypt = async (accessToken = {}) => {
+  const {ciphertext, nonce} = accessToken
+
+  try {
+    await sodium.ready
+    const decrypted = Buffer.from(
+      sodium.crypto_secretbox_open_easy(
+        Buffer.from(ciphertext, 'hex'),
+        Buffer.from(nonce, 'hex'),
+        Buffer.from(key, 'hex'),
+      ),
+    )
+    return sodium.to_string(decrypted)
+  } catch (e) {
+    console.error(e)
+    return null
+  }
 }
 
 const encryptionKeygen = async () => {

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -1,4 +1,6 @@
 import {decrypt} from '../encryption.js'
+import {Low, JSONFile} from 'lowdb'
+import seedData from '../seedData.js'
 
 const parseJSON = async response => {
   const text = await response.text()
@@ -28,4 +30,11 @@ const findAccountWithMatchingToken = async (
   return null
 }
 
-export {parseJSON, findAccountWithMatchingToken}
+const syncDB = async () => {
+  const db = new Low(new JSONFile('localdb.json'))
+  await db.read()
+  db.data = seedData
+  await db.write()
+}
+
+export {parseJSON, findAccountWithMatchingToken, syncDB}

--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
       "node"
     ],
     "moduleNameMapper": {
-      ".+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2|svg)$": "identity-obj-proxy"
+      ".+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2|svg)$": "identity-obj-proxy",
+      "#(.*)": "<rootDir>/node_modules/$1"
     }
   },
   "lint-staged": {

--- a/routes/oauth.js
+++ b/routes/oauth.js
@@ -14,6 +14,7 @@
 import express from 'express'
 import database from '../db.js'
 import fetch from 'node-fetch'
+import chalk from 'chalk'
 import {parseJSON, findAccountWithMatchingToken} from '../helpers/index.js'
 import {encrypt, decrypt} from '../encryption.js'
 const {createHmac, timingSafeEqual} = await import('node:crypto')
@@ -150,7 +151,10 @@ oauthRouter.post('/api/checkr/webhooks', async (req, res) => {
   }
 
   const db = await database()
-  console.log('Handling webhook: ', req.body.type)
+  console.log(
+    chalk.black.bgGreen(' Handling webhook '),
+    chalk.black.bgYellow(` ${req.body.type} `),
+  )
   // Use the webhook payload's ```type``` property to determine what to do with
   // the event.
   switch (req.body.type) {
@@ -247,6 +251,13 @@ oauthRouter.post('/api/checkr/webhooks', async (req, res) => {
         db.data.accounts,
         checkrAccessToken,
       )
+
+      if (!accountToDisconnect) {
+        res.status(404).send({
+          errors: ['cannot find account with matching checkr access token'],
+        })
+        return
+      }
 
       // Here, we mark the Checkr account as ```disconnected```. If your user
       // decides to reconnect your integration with their Checkr account, the

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ import chalk from 'chalk'
 import morgan from 'morgan'
 import ngrok from 'ngrok'
 import express from 'express'
+import {syncDB} from './helpers/index.js'
 import candidatesRouter from './routes/candidates.js'
 import accountsRouter from './routes/accounts.js'
 import embedsSessionTokensRouter from './routes/embeds-session-tokens.js'
@@ -38,6 +39,7 @@ if (process.env.NODE_ENV === 'production') {
   })()
 }
 
+await syncDB()
 app.listen(port)
 console.log(
   chalk.black.bgWhite(' Private API URL '),


### PR DESCRIPTION
Our database function would write on every request `(GET/POST)` causing the db to be unable to be found at times when 2 requests would come in at the same time (GET /candidates, GET /accounts) and crashing the backend.

```
[1] node:internal/process/promises:279
[1]             triggerUncaughtException(err, true /* fromPromise */);
[1]             ^
[1] 
[1] [Error: ENOENT: no such file or directory, rename '.localdb.json.tmp' -> 'localdb.json'] {
[1]   errno: -2,
[1]   code: 'ENOENT',
[1]   syscall: 'rename',
[1]   path: '.localdb.json.tmp',
[1]   dest: 'localdb.json'
[1] }
```