### PR TITLE
Set default variables for runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,6 @@ FROM node:16.19.0
 
 WORKDIR /usr/src/app
 
-ARG NODE_ENV=production
-ARG REACT_APP_CHECKR_OAUTH_CLIENT_ID=${REACT_APP_CHECKR_OAUTH_CLIENT_ID}
-ARG REACT_APP_CHECKR_PARTNER_URL=${REACT_APP_CHECKR_PARTNER_URL}
-
 COPY . .
 RUN yarn install --frozen-lockfile
 RUN yarn heroku-postbuild

--- a/bin/generate_chart.sh
+++ b/bin/generate_chart.sh
@@ -27,7 +27,7 @@ printf "        S3_ACCESS_KEY_SECRET: ${S3_ACCESS_KEY_SECRET}\n" >> .gitops/helm
 printf "        S3_BUCKET: ${S3_BUCKET}\n" >> .gitops/helm/oauth-reference-integration/production.yaml
 printf "  deployments:\n" >> .gitops/helm/oauth-reference-integration/production.yaml
 printf "    web:\n" >> .gitops/helm/oauth-reference-integration/production.yaml
-printf "      command: ['env', 'node', 'server.js']\n" >> .gitops/helm/oauth-reference-integration/production.yaml
+printf "      command: ['node', 'server.js']\n" >> .gitops/helm/oauth-reference-integration/production.yaml
 printf "      replicaCount: $REPLICA_COUNT\n\n" >> .gitops/helm/oauth-reference-integration/production.yaml
 printf "  ingresses:\n" >> .gitops/helm/oauth-reference-integration/production.yaml
 printf "    web:\n" >> .gitops/helm/oauth-reference-integration/production.yaml

--- a/bin/generate_chart.sh
+++ b/bin/generate_chart.sh
@@ -27,7 +27,7 @@ printf "        S3_ACCESS_KEY_SECRET: ${S3_ACCESS_KEY_SECRET}\n" >> .gitops/helm
 printf "        S3_BUCKET: ${S3_BUCKET}\n" >> .gitops/helm/oauth-reference-integration/production.yaml
 printf "  deployments:\n" >> .gitops/helm/oauth-reference-integration/production.yaml
 printf "    web:\n" >> .gitops/helm/oauth-reference-integration/production.yaml
-printf "      command: ['node', 'server.js']\n" >> .gitops/helm/oauth-reference-integration/production.yaml
+printf "      command: ['env', 'node', 'server.js']\n" >> .gitops/helm/oauth-reference-integration/production.yaml
 printf "      replicaCount: $REPLICA_COUNT\n\n" >> .gitops/helm/oauth-reference-integration/production.yaml
 printf "  ingresses:\n" >> .gitops/helm/oauth-reference-integration/production.yaml
 printf "    web:\n" >> .gitops/helm/oauth-reference-integration/production.yaml

--- a/client/src/components/account/CheckrConnectLink.js
+++ b/client/src/components/account/CheckrConnectLink.js
@@ -27,7 +27,7 @@ export default function CheckrConnectLink({customerAccountID}) {
   // Replace the customerAccountID with your account-level identifier
   // </details>
   const checkrSignupFlowHref = customerAccountID => {
-    const signupFlowLink = `${process.env.REACT_APP_CHECKR_PARTNER_URL}/authorize/${process.env.REACT_APP_CHECKR_OAUTH_CLIENT_ID}/signup`
+    const signupFlowLink = `${process.env.REACT_APP_CHECKR_PARTNER_URL || 'https://partners.checkrhq-staging.net'}/authorize/${process.env.REACT_APP_CHECKR_OAUTH_CLIENT_ID || 'e9ba3ef42210976905cd933f'}/signup`
     const state = customerAccountID
 
     const url = new URL(signupFlowLink)


### PR DESCRIPTION
`process.env` doesn't work on the client (maybe only if we do a local build/run?)